### PR TITLE
chore(linting): update Ruff lint configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,10 +123,12 @@ indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-    "S101",    # assert
-    "INP001"   # implicit-namespace-package
+select = [
+    'F',      # Pyflakes
+    'E',      # pycodestyle (Error)
+    'I',      # isort
+    'D',      # pydocstyle
+    'UP',     # pyupgrade
 ]
 pydocstyle = { convention = "google" }
 


### PR DESCRIPTION
This commit refines the Ruff lint configuration by:
- Explicitly selecting specific lint categories (Pyflakes, pycodestyle, etc)
- Removing the previous blanket 'ALL' selection
- Removing individual ignore rules that are no longer needed

The change makes the lint configuration more intentional and maintainable by explicitly declaring what we want rather than using broad selections with exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated code linting configuration to focus on a specific set of rule categories for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->